### PR TITLE
Update likes_inclusion_tags.py

### DIFF
--- a/likes/templatetags/likes_inclusion_tags.py
+++ b/likes/templatetags/likes_inclusion_tags.py
@@ -16,12 +16,16 @@ def likes(context, obj, template=None):
     if not hasattr(request, '_django_likes_js_imported'):
         setattr(request, '_django_likes_js_imported', 1)
         import_js = True
+    try:
+        model_name = obj._meta.model_name
+    except AttributeError:
+        model_name = obj._meta.module_name
     context.update({
         'template': template,
         'content_obj': obj,
         'likes_enabled': likes_enabled(obj, request),
         'can_vote': can_vote(obj, request.user, request),
-        'content_type': "-".join((obj._meta.app_label, obj._meta.model_name)),
+        'content_type': "-".join((obj._meta.app_label, model_name)),
         'import_js': import_js
     })
     return context


### PR DESCRIPTION
Python-digest project includes your library. Your version is outdated. In this file you call `obj._meta.module_name`. This call is deprecated.